### PR TITLE
BUGFIX: Catch `context.Canceled` errors and exit as if nothing went wrong

### DIFF
--- a/run.go
+++ b/run.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"syscall"
@@ -37,6 +38,9 @@ func runWithGracefulShutdown(ctx context.Context, cmd *exec.Cmd) error {
 
 	waitErr := cmd.Wait()
 	if interruptErr := <-errc; interruptErr != nil {
+		if errors.Is(interruptErr, context.Canceled) {
+			return nil
+		}
 		return interruptErr
 	}
 	if waitErr != nil {


### PR DESCRIPTION
Hi! First of all thank you for open sourcing this, I think this is a really nice & simple tool to workaround the sidecar limitations 👍

This PR is at least partially a question as I'm not 100% sure that I didn't screw up the usage.
I'm using `wait-for` to shutdown fluentd in a Kubernetes Job when the primary container has stopped.
This is working nicely, except that `wait-for` always exits with a exit code of one and the following logs:

```
...
fluentd: 2023-02-02 12:30:17 +0000 [info]: Received graceful stop
fluentd: 2023-02-02 12:30:18 +0000 [info]: #0 fluentd worker is now stopping worker=0
fluentd: 2023-02-02 12:30:18 +0000 [info]: #0 shutting down fluentd worker worker=0
fluentd: 2023-02-02 12:30:18 +0000 [info]: #0 shutting down input plugin type=:tail plugin_id="object:744"
fluentd: 2023-02-02 12:30:19 +0000 [info]: #0 shutting down output plugin type=:elasticsearch_data_stream plugin_id="object:71c"
fluentd: 2023-02-02 12:30:19 +0000 [info]: Worker 0 finished with status 0
wait-for: 2023/02/02 13:14:19 command exited with error: context canceled
```

I'm starting wait-for with the following flags:

```yaml
- "/wait-for/wait-for"
- "-wait-stop=tcp://:8080"
- "-wait-stop-retry=30"
- "--"
- "<fluentd command here>"
``` 

I'm pretty sure that fluentd is exiting with a exit code 0, but not 💯

When looking at the code I'm suspecting that it's because the context cancellation is considered to en an error, even thought it is expected behavior as it's coming from the stop check?